### PR TITLE
Some Minor Consistency

### DIFF
--- a/BurgerKingFootLettuce_A3_Part1_v0.md
+++ b/BurgerKingFootLettuce_A3_Part1_v0.md
@@ -12,18 +12,18 @@ Below is a list of supported currencies that can be used as the **to** and **fro
 - American Dollar.
 - Canadian Dollar.
 
-> When we refer to a {validCoin}, it has to be the same as one of the items in the list
+> When we refer to a {validCurrency}, it has to be the same as one of the items in the list
 
 ## List of Endpoints with Parameters
 
 ### convertCurrency Endpoint
 
-GET `api/convertCurrency?from={ValidCoin}&to={ValidCoin}&amount={number}`
+GET `convertCurrency?from={validCurrency}&to={validCurrency}&amount={number}`
 
 The parameters are:
 
-- **from**: must be a string of type {ValidCoin}.
-- **to**: must be a string of type {ValidCoin}.
+- **from**: must be a string of type {validCurrency}.
+- **to**: must be a string of type {validCurrency}.
 - **amount**: must be number.
 
 ## Description of Resources - formatted as JSON
@@ -33,8 +33,8 @@ The parameters are:
 The response will have 3 parameters:
 
 - **amountConverted** (number): The value of the currency after it has been converted to the currency of the *to* parameter.
-- **from** (string): The currency type that is being converted. This will be a {validCoin} type.
-- **to** (string): The currency type that the *from* parameter is being converted into. This will be a {validCoin} type.
+- **from** (string): The currency type that is being converted. This will be a {validCurrency} type.
+- **to** (string): The currency type that the *from* parameter is being converted into. This will be a {validCurrency} type.
 
 Example:
 
@@ -50,7 +50,7 @@ Example:
 
 The API request looks like this:
 
-GET `api/convertCurrency?from=DogeCoin&to=Bitcoin&amount=1`
+GET `convertCurrency?from=DogeCoin&to=Bitcoin&amount=1`
 
 A successful response looks like this:
 


### PR DESCRIPTION
I changed two little things

1. Changed the path to just be `convertCurrency` as the /api can be part of the server URL and in swagger it looks a little bit better
2. I belive that we should change `validCoin` to `validCurrency` as we are allowing the user to change from cryptocurrency to 'legal tender' which technically is not a coin. Also we've been using currency for the name of the api, i think we should be consistent and keep using it for the api response